### PR TITLE
Clean up mod integration classes

### DIFF
--- a/src/main/java/tonius/simplyjetpacks/integration/EIOItems.java
+++ b/src/main/java/tonius/simplyjetpacks/integration/EIOItems.java
@@ -1,5 +1,6 @@
 package tonius.simplyjetpacks.integration;
 
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import tonius.simplyjetpacks.SimplyJetpacks;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -7,63 +8,43 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
 public abstract class EIOItems {
-	public static ItemStack capacitorBankOld;
+
+	//capacitor banks
+	@GameRegistry.ItemStackHolder(value = "enderio:block_cap_bank", meta = 1)
 	public static ItemStack capacitorBankBasic;
+	@GameRegistry.ItemStackHolder(value = "enderio:block_cap_bank", meta = 2)
 	public static ItemStack capacitorBank;
+	@GameRegistry.ItemStackHolder(value = "enderio:block_cap_bank", meta = 3)
 	public static ItemStack capacitorBankVibrant;
+
+	//conduits
+	@GameRegistry.ItemStackHolder("enderio:item_redstone_conduit")
 	public static ItemStack redstoneConduit;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_power_conduit", meta = 0)
 	public static ItemStack energyConduit1;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_power_conduit", meta = 1)
 	public static ItemStack energyConduit2;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_power_conduit", meta = 2)
 	public static ItemStack energyConduit3;
+
+	//capacitor items
+	@GameRegistry.ItemStackHolder(value = "enderio:item_basic_capacitor", meta = 0)
 	public static ItemStack basicCapacitor;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_basic_capacitor", meta = 1)
 	public static ItemStack doubleCapacitor;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_basic_capacitor", meta = 2)
 	public static ItemStack octadicCapacitor;
+
+	//crafting materials
+	@GameRegistry.ItemStackHolder(value = "enderio:item_material", meta = 1)
 	public static ItemStack machineChassis;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_material", meta = 9)
 	public static ItemStack basicGear;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_material", meta = 14)
 	public static ItemStack pulsatingCrystal;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_material", meta = 15)
 	public static ItemStack vibrantCrystal;
+	@GameRegistry.ItemStackHolder(value = "enderio:item_material", meta = 16)
 	public static ItemStack enderCrystal;
 
-	public static void init() {
-		SimplyJetpacks.logger.info("Stealing Ender IO's items");
-
-		capacitorBankOld = new ItemStack(Block.REGISTRY.getObject(new ResourceLocation("enderio", "blockCapacitorBank")));
-
-		Block capBankBlock = Block.REGISTRY.getObject(new ResourceLocation("enderio", "blockCapBank"));
-		capacitorBankBasic = new ItemStack(capBankBlock, 1, 1);
-		capacitorBank = new ItemStack(capBankBlock, 1, 2);
-		capacitorBankVibrant = new ItemStack(capBankBlock, 1, 3);
-
-		Item redstoneConduitItem = Item.REGISTRY.getObject(new ResourceLocation("enderio", "itemRedstoneConduit"));
-		if (redstoneConduitItem != null) {
-			redstoneConduit = new ItemStack(redstoneConduitItem, 1, 0);
-		}
-
-		Item energyConduitItem = Item.REGISTRY.getObject(new ResourceLocation("enderio", "itemPowerConduit"));
-		if (energyConduitItem != null) {
-			energyConduit1 = new ItemStack(energyConduitItem, 1, 0);
-			energyConduit2 = new ItemStack(energyConduitItem, 1, 1);
-			energyConduit3 = new ItemStack(energyConduitItem, 1, 2);
-		}
-
-		Item capacitorItem = Item.REGISTRY.getObject(new ResourceLocation("enderio", "itemBasicCapacitor"));
-		if (capacitorItem != null) {
-			basicCapacitor = new ItemStack(capacitorItem, 1, 0);
-			doubleCapacitor = new ItemStack(capacitorItem, 1, 1);
-			octadicCapacitor = new ItemStack(capacitorItem, 1, 2);
-		}
-
-		Item machinePartItem = Item.REGISTRY.getObject(new ResourceLocation("enderio", "itemMachinePart"));
-		if (machinePartItem != null) {
-			machineChassis = new ItemStack(machinePartItem, 1, 0);
-			basicGear = new ItemStack(machinePartItem, 1, 1);
-		}
-
-		Item materialsItem = Item.REGISTRY.getObject(new ResourceLocation("enderio", "itemMaterial"));
-		if (materialsItem != null) {
-			pulsatingCrystal = new ItemStack(materialsItem, 1, 5);
-			vibrantCrystal = new ItemStack(materialsItem, 1, 6);
-			enderCrystal = new ItemStack(materialsItem, 1, 8);
-		}
-	}
 }

--- a/src/main/java/tonius/simplyjetpacks/integration/RAItems.java
+++ b/src/main/java/tonius/simplyjetpacks/integration/RAItems.java
@@ -3,26 +3,12 @@ package tonius.simplyjetpacks.integration;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import tonius.simplyjetpacks.SimplyJetpacks;
 
 public abstract class RAItems {
-
-	public static Item material;
-	public static Item armorPlate;
+	@GameRegistry.ItemStackHolder("redstonearsenal:armor.plate_flux")
 	public static ItemStack armorChestPlate;
+	@GameRegistry.ItemStackHolder(value = "redstonearsenal:material", meta = 224)
 	public static ItemStack fluxPlating;
-
-	public static void init() {
-		SimplyJetpacks.logger.info("Stealing Redstone Arsenal's items");
-
-		material = Item.REGISTRY.getObject(new ResourceLocation("redstonearsenal", "material"));
-		if (material != null) {
-			fluxPlating = new ItemStack(material, 1, 224);
-		}
-
-		armorPlate = Item.REGISTRY.getObject(new ResourceLocation("redstonearsenal", "armor.plate_flux"));
-		if (armorPlate != null) {
-			armorChestPlate = new ItemStack(armorPlate, 1, 0);
-		}
-	}
 }

--- a/src/main/java/tonius/simplyjetpacks/integration/TDItems.java
+++ b/src/main/java/tonius/simplyjetpacks/integration/TDItems.java
@@ -3,25 +3,21 @@ package tonius.simplyjetpacks.integration;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import tonius.simplyjetpacks.Log;
 
 public abstract class TDItems {
 
-	public static Block ductFlux = null;
+	@GameRegistry.ItemStackHolder(value = "thermaldynamics:duct_0", meta = 0)
 	public static ItemStack ductFluxLeadstone = null;
+	@GameRegistry.ItemStackHolder(value = "thermaldynamics:duct_0", meta = 1)
 	public static ItemStack ductFluxHardened = null;
+	@GameRegistry.ItemStackHolder(value = "thermaldynamics:duct_0", meta = 2)
 	public static ItemStack ductFluxRedstoneEnergy = null;
+	@GameRegistry.ItemStackHolder(value = "thermaldynamics:duct_0", meta = 4)
 	public static ItemStack ductFluxResonant = null;
 
 	public static void init() {
 		Log.info("Stealing Thermal Dynamics's items");
-
-		ductFlux = Block.REGISTRY.getObject(new ResourceLocation("thermaldynamics", "duct_0"));
-		if (ductFlux != null) {
-			ductFluxLeadstone = new ItemStack(ductFlux, 1, 0);
-			ductFluxHardened = new ItemStack(ductFlux, 1, 1);
-			ductFluxRedstoneEnergy = new ItemStack(ductFlux, 1, 2);
-			ductFluxResonant = new ItemStack(ductFlux, 1, 4);
-		}
 	}
 }

--- a/src/main/java/tonius/simplyjetpacks/integration/TDItems.java
+++ b/src/main/java/tonius/simplyjetpacks/integration/TDItems.java
@@ -17,7 +17,4 @@ public abstract class TDItems {
 	@GameRegistry.ItemStackHolder(value = "thermaldynamics:duct_0", meta = 4)
 	public static ItemStack ductFluxResonant = null;
 
-	public static void init() {
-		Log.info("Stealing Thermal Dynamics's items");
-	}
 }

--- a/src/main/java/tonius/simplyjetpacks/integration/TEItems.java
+++ b/src/main/java/tonius/simplyjetpacks/integration/TEItems.java
@@ -16,72 +16,61 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public abstract class TEItems {
 
-	public static Item capacitor = null;
-	public static Block dynamo = null;
-	public static Item material = null;
-	public static Item cell = null;
-	public static Item glass_alloy = null;
+	//capacitors
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:capacitor", meta = 0)
 	public static ItemStack capacitorBasic = null;
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:capacitor", meta = 1)
 	public static ItemStack capacitorHardened = null;
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:capacitor", meta = 2)
 	public static ItemStack capacitorReinforced = null;
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:capacitor", meta = 4)
 	public static ItemStack capacitorResonant = null;
+
+	//cells
+	@GameRegistry.ItemStackHolder("thermalexpansion:cell")
 	public static ItemStack cellBasic = null;
+	@GameRegistry.ItemStackHolder("thermalexpansion:cell")
 	public static ItemStack cellReinforced = null;
-	public static ItemStack bucketRedstone = null;
-	public static ItemStack dynamoReactant = null;
-	public static ItemStack dynamoMagmatic = null;
-	public static ItemStack dynamoEnervation = null;
-	public static ItemStack dynamoSteam = null;
-	public static ItemStack signalumGlass = null;
-	public static ItemStack frameIlluminator = null;
-	public static ItemStack pneumaticServo = null;
-	public static ItemStack powerCoilElectrum = null;
-	public static ItemStack powerCoilGold = null;
+	@GameRegistry.ItemStackHolder("thermalexpansion:cell")
 	public static ItemStack cellResonant;
+
+	//dynamos
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:dynamo", meta = 0)
+	public static ItemStack dynamoReactant = null;
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:dynamo", meta = 1)
+	public static ItemStack dynamoMagmatic = null;
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:dynamo", meta = 3)
+	public static ItemStack dynamoSteam = null;
+	@GameRegistry.ItemStackHolder(value = "thermalexpansion:dynamo", meta = 4)
+	public static ItemStack dynamoEnervation = null;
+
+	//materials
+	@GameRegistry.ItemStackHolder(value = "thermalfoundation:glass_alloy", meta = 5)
+	public static ItemStack signalumGlass = null;
+	@GameRegistry.ItemStackHolder(value = "thermalfoundation:material", meta = 513)
+	public static ItemStack powerCoilGold = null;
+	@GameRegistry.ItemStackHolder(value = "thermalfoundation:material", meta = 515)
+	public static ItemStack powerCoilElectrum = null;
+
+	public static ItemStack bucketRedstone = null;
+
 
 	public static void init() {
 		SimplyJetpacks.logger.info("Stealing Thermal Expansion's items");
-
-		capacitor = Item.REGISTRY.getObject(new ResourceLocation("thermalexpansion", "capacitor"));
-		if (capacitor != null) {
-			capacitorBasic = new ItemStack(capacitor, 1, 0);
-			capacitorHardened = new ItemStack(capacitor, 1, 1);
-			capacitorReinforced = new ItemStack(capacitor, 1, 2);
-			capacitorResonant = new ItemStack(capacitor, 1, 4);
-		}
-
-		dynamo = Block.REGISTRY.getObject(new ResourceLocation("thermalexpansion", "dynamo"));
-		if (dynamo != null) {
-			dynamoSteam = new ItemStack(dynamo, 1, 0);
-			dynamoMagmatic = new ItemStack(dynamo, 1, 1);
-			dynamoReactant = new ItemStack(dynamo, 1, 3);
-			dynamoEnervation = new ItemStack(dynamo, 1, 4);
-		}
-
-		material = Item.REGISTRY.getObject(new ResourceLocation("thermalfoundation", "material"));
-		if (material != null) {
-			powerCoilGold = new ItemStack(material, 1, 513);
-			powerCoilElectrum = new ItemStack(material, 1, 515);
-		}
-
-		cell = Item.REGISTRY.getObject(new ResourceLocation("thermalexpansion", "cell"));
-		if (cell != null) {
-			cellBasic = new ItemStack(cell);
+		boolean c = cellReinforced == null;
+		System.out.println(c + " null check boi");
+		if (cellBasic != null) {
 			cellBasic.setTagCompound(new NBTTagCompound());
 			cellBasic.getTagCompound().setByte("Level", (byte) 0);
-
-			cellReinforced = new ItemStack(cell);
+		}
+		if (cellReinforced != null) {
 			cellReinforced.setTagCompound(new NBTTagCompound());
 			cellReinforced.getTagCompound().setByte("Level", (byte) 2);
-
-			cellResonant = new ItemStack(cell);
+			System.out.println("nbt set boi");
+		}
+		if (cellResonant != null){
 			cellResonant.setTagCompound(new NBTTagCompound());
 			cellResonant.getTagCompound().setByte("Level", (byte) 4);
-		}
-
-		glass_alloy = Item.REGISTRY.getObject(new ResourceLocation("thermalfoundation", "glass_alloy"));
-		if (glass_alloy != null) {
-			signalumGlass = new ItemStack(glass_alloy, 1, 5);
 		}
 	}
 

--- a/src/main/java/tonius/simplyjetpacks/integration/TEItems.java
+++ b/src/main/java/tonius/simplyjetpacks/integration/TEItems.java
@@ -57,8 +57,7 @@ public abstract class TEItems {
 
 	public static void init() {
 		SimplyJetpacks.logger.info("Stealing Thermal Expansion's items");
-		boolean c = cellReinforced == null;
-		System.out.println(c + " null check boi");
+
 		if (cellBasic != null) {
 			cellBasic.setTagCompound(new NBTTagCompound());
 			cellBasic.getTagCompound().setByte("Level", (byte) 0);
@@ -66,7 +65,6 @@ public abstract class TEItems {
 		if (cellReinforced != null) {
 			cellReinforced.setTagCompound(new NBTTagCompound());
 			cellReinforced.getTagCompound().setByte("Level", (byte) 2);
-			System.out.println("nbt set boi");
 		}
 		if (cellResonant != null){
 			cellResonant.setTagCompound(new NBTTagCompound());

--- a/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
+++ b/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
@@ -121,16 +121,10 @@ public abstract class ModItems {
 	public static boolean integrateVanilla = Config.enableIntegrationVanilla;
 
 	public static void preInit() {
-		if (integrateEIO) {
-			EIOItems.init();
-		}
 		if (integrateTE) {
 			TEItems.init();
 			if (integrateTD) {
 				TDItems.init();
-			}
-			if (integrateRA) {
-				RAItems.init();
 			}
 		}
 
@@ -198,6 +192,10 @@ public abstract class ModItems {
 
 		leatherStrap = MetaItems.LEATHER_STRAP.getStackMetaItem();
 
+
+	}
+
+	public static void gatherIngredients(){
 
 		if (integrateEIO) {
 			ingotDarkSoularium = MetaItemsMods.INGOT_DARK_SOULARIUM.getStackMetaItem();
@@ -288,6 +286,7 @@ public abstract class ModItems {
 	}
 
 	public static void registerRecipes() {
+		gatherIngredients();
 		RecipeHandler.addOreDictRecipe(leatherStrap, "LIL", "LIL", 'L', Items.LEATHER, 'I', "ingotIron");
 		ForgeRegistries.RECIPES.register(new UpgradingRecipe(jetpackCreative, "J", "P", 'J', jetpackCreative, 'P', "particleCustomizer"));
 

--- a/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
+++ b/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
@@ -121,13 +121,6 @@ public abstract class ModItems {
 	public static boolean integrateVanilla = Config.enableIntegrationVanilla;
 
 	public static void preInit() {
-		if (integrateTE) {
-//			TEItems.init();
-			if (integrateTD) {
-				TDItems.init();
-			}
-		}
-
 		registerItems();
 		registerOreDicts();
 	}

--- a/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
+++ b/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
@@ -367,7 +367,6 @@ public abstract class ModItems {
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(jetpackTE5, "PAP", "OJO", "TCT", 'A', armorFluxPlate, 'J', jetpackTE4Armored, 'O', unitCryotheum, 'C', fluxPackTE3Armored, 'T', thrusterTE5, 'P', plateFlux));
 
 
-			System.out.println("register boi");
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(fluxPackTE1, "ICI", "ISI", 'I', "ingotLead", 'C', TEItems.cellBasic, 'S', leatherStrap));
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(fluxPackTE2, " C ", "ISI", "LOL", 'I', "ingotElectrum", 'L', "ingotLead", 'C', TEItems.cellReinforced, 'S', fluxPackTE1, 'O', TEItems.powerCoilElectrum));
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(fluxPackTE3, " C ", "ISI", "LOL", 'I', "ingotEnderium", 'L', "ingotLead", 'C', TEItems.cellResonant, 'S', fluxPackTE2, 'O', TEItems.powerCoilElectrum));

--- a/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
+++ b/src/main/java/tonius/simplyjetpacks/setup/ModItems.java
@@ -122,7 +122,7 @@ public abstract class ModItems {
 
 	public static void preInit() {
 		if (integrateTE) {
-			TEItems.init();
+//			TEItems.init();
 			if (integrateTD) {
 				TDItems.init();
 			}
@@ -232,6 +232,7 @@ public abstract class ModItems {
 		}
 
 		if (integrateTE) {
+				TEItems.init();
 			thrusterTE1 = MetaItemsMods.THRUSTER_TE_1.getStackMetaItem();
 			thrusterTE2 = MetaItemsMods.THRUSTER_TE_2.getStackMetaItem();
 			thrusterTE3 = MetaItemsMods.THRUSTER_TE_3.getStackMetaItem();
@@ -341,7 +342,7 @@ public abstract class ModItems {
 				RecipeHandler.addOreDictRecipe(plateFlux, "NNN", "GIG", "NNN", 'G', Items.DIAMOND, 'I', "ingotSignalum", 'N', "nuggetSignalum");
 				RecipeHandler.addOreDictRecipe(armorFluxPlate, "I I", "III", "III", 'I', plateFlux);
 				RecipeHandler.addOreDictRecipe(unitCryotheumEmpty, "FTF", "THT", "FTF", 'T', "ingotTin", 'F', "ingotSignalum", 'H', "blockGlassHardened");
-				RecipeHandler.addOreDictRecipe(unitGlowstoneEmpty, "FLF", "LHL", "FLF", 'L', "ingotLumium", 'F', "ingotSignalum", 'H', TEItems.glass_alloy); //TODO: Change Glowstone to lamp
+				RecipeHandler.addOreDictRecipe(unitGlowstoneEmpty, "FLF", "LHL", "FLF", 'L', "ingotLumium", 'F', "ingotSignalum", 'H', TEItems.signalumGlass); //TODO: Change Glowstone to lamp
 			}
 
 			Object ductFluxLeadstone = integrateTD ? TDItems.ductFluxLeadstone : "blockGlass";
@@ -372,6 +373,8 @@ public abstract class ModItems {
 			ForgeRegistries.RECIPES.register(new UpgradingRecipeShapeless(jetpackTE4Armored, jetpackTE4, armorPlatingTE4));
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(jetpackTE5, "PAP", "OJO", "TCT", 'A', armorFluxPlate, 'J', jetpackTE4Armored, 'O', unitCryotheum, 'C', fluxPackTE3Armored, 'T', thrusterTE5, 'P', plateFlux));
 
+
+			System.out.println("register boi");
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(fluxPackTE1, "ICI", "ISI", 'I', "ingotLead", 'C', TEItems.cellBasic, 'S', leatherStrap));
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(fluxPackTE2, " C ", "ISI", "LOL", 'I', "ingotElectrum", 'L', "ingotLead", 'C', TEItems.cellReinforced, 'S', fluxPackTE1, 'O', TEItems.powerCoilElectrum));
 			ForgeRegistries.RECIPES.register(new UpgradingRecipe(fluxPackTE3, " C ", "ISI", "LOL", 'I', "ingotEnderium", 'L', "ingotLead", 'C', TEItems.cellResonant, 'S', fluxPackTE2, 'O', TEItems.powerCoilElectrum));


### PR DESCRIPTION
This PR moves recipe integration over to the ObjectHolder system, which is better suited for what we are doing here and more resilient to registry modification, as well as more recent and documented. 
