### PR TITLE
Moved hard dep on TE over to RF api, no longer requires TE to launch.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,14 +46,15 @@ dependencies {
     // compile against the JEI API
     //deobfCompile "mezz.jei:jei_1.10.2:3.14.7.420:api"
     // at runtime, use the full JEI jar
-    //runtime "mezz.jei:jei_1.10.2:3.14.7.420"
+    runtime "mezz.jei:jei_1.12.2:4.9.+"
     //deobfCompile "cofh:RedstoneFlux:1.12-2.0.1.2:universal"
-    compile "codechicken:CodeChickenLib:1.12.2-3.1.7.+:deobf"
-    compile "cofh:CoFHCore:1.12.2-4.4.+:deobf"
-    compile "cofh:ThermalFoundation:1.12.2-2.4.+:deobf"
-    compile "cofh:ThermalDynamics:1.12.2-2.4.+:deobf"
-    compile "cofh:ThermalExpansion:1.12.2-5.4.+:deobf"
-    compile "cofh:RedstoneArsenal:1.12.2-2.4.+:deobf"
+//    compile "codechicken:CodeChickenLib:1.12.2-3.1.7.+:deobf"
+//    compile "cofh:CoFHCore:1.12.2-4.4.+:deobf"
+//    compile "cofh:ThermalFoundation:1.12.2-2.4.+:deobf"
+    runtime "cofh:ThermalDynamics:1.12.2-2.4.+:universal"
+    runtime "cofh:ThermalExpansion:1.12.2-5.4.+:universal"
+    runtime "cofh:RedstoneArsenal:1.12.2-2.4.+:universal"
+    compile "cofh:RedstoneFlux:1.12-2.0.1.+:deobf"
 }
 
 minecraft {

--- a/src/main/java/tonius/simplyjetpacks/SimplyJetpacks.java
+++ b/src/main/java/tonius/simplyjetpacks/SimplyJetpacks.java
@@ -26,7 +26,7 @@ public class SimplyJetpacks {
 	public static final String VERSION = "@VERSION@";
 	public static final String PREFIX = MODID + ".";
 	public static final String RESOURCE_PREFIX = MODID + ":";
-	public static final String DEPENDENCIES = "required-after:thermalexpansion@[5.4.0,);" + "after:redstonearsenal;" + "after:thermaldynamics;";
+	public static final String DEPENDENCIES = "required-after:redstoneflux@[2.0.1,);" + "after:thermalexpansion;" + "after:redstonearsenal;" + "after:thermaldynamics;";
 	public static final String GUI_FACTORY = "tonius.simplyjetpacks.config.ConfigGuiFactory";
 	public static final String UPDATE_JSON = "https://raw.githubusercontent.com/Tomson124/SimplyJetpacks-2/1.12/update/update.json";
 


### PR DESCRIPTION
This is just a simple change to no longer have a hard dependency on Thermal Expansion, as we are not using it for anything more than pulling in the RF API in a very roundabout way. 

Additionally, there is very little use for the vanilla jetpacks if TE is assured to be in every pack with SJ2 because of a hard dep. This makes vanilla-only SJ2 play possible. 

In the future, the RF API should be replaced by a pure Capability implementation, which shouldn't be a difficult task at all. 