### PR TITLE
Make enchantment methods more compatible with other mods

### DIFF
--- a/src/main/java/tonius/simplyjetpacks/item/ItemJetpack.java
+++ b/src/main/java/tonius/simplyjetpacks/item/ItemJetpack.java
@@ -303,9 +303,9 @@ public class ItemJetpack extends ItemArmor implements ISpecialArmor, IEnergyCont
 	@Override
 	public int getMaxEnergyStored(ItemStack container) {
 		int i = MathHelper.clamp(container.getItemDamage(), 0, numItems - 1);
-		int id = StackUtil.getEnchantmentIdByName("holding", container);
+		int id = StackUtil.getEnchantmentIdByName("cofhcore:holding", container);
 		if(id != -1){
-			return Jetpack.values()[i].getFuelCapacity() + Jetpack.values()[i].getFuelCapacity() * StackUtil.getEnchantmentLevel(id, container) / 2;
+			return Jetpack.values()[i].getFuelCapacity() + Jetpack.values()[i].getFuelCapacity() * EnchantmentHelper.getEnchantmentLevel(Enchantment.getEnchantmentByID(id), container) / 2;
 		}
 		return Jetpack.values()[i].getFuelCapacity();
 	}

--- a/src/main/java/tonius/simplyjetpacks/util/StackUtil.java
+++ b/src/main/java/tonius/simplyjetpacks/util/StackUtil.java
@@ -1,11 +1,11 @@
 package tonius.simplyjetpacks.util;
 
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import tonius.simplyjetpacks.Log;
 
 public final class StackUtil {
 
@@ -19,43 +19,20 @@ public final class StackUtil {
 		return stack.getItem();
 	}
 
-
-	//thx to cofh for parts of this method
-	public static int getEnchantmentLevel(int id, ItemStack stack) {
-		if (stack.isEmpty()) {
-			return 0;
-		}
-		else {
-			NBTTagList nbttaglist = stack.getEnchantmentTagList();
-
-			for (int i = 0; i < nbttaglist.tagCount(); ++i)	{
-				NBTTagCompound nbttagcompound = nbttaglist.getCompoundTagAt(i);
-				int stackId = nbttagcompound.getShort("id");
-				int j = nbttagcompound.getShort("lvl");
-
-				if (id == stackId) {
-					return j;
-				}
-			}
-			return 0;
-		}
-	}
-
 	//gets the enchantment ID on an item when passed a portion of the enchantment's name
 	// returns -1 if enchantment is not applied or stack is empty
 	public static int getEnchantmentIdByName(String name, ItemStack stack) {
-		if (stack.isEmpty()) {
-			return -1;
+		Enchantment ench = Enchantment.getEnchantmentByLocation(name);
+
+		if (!stack.isEmpty()) {
+			if (EnchantmentHelper.getEnchantments(stack).containsKey(ench)) {
+				return Enchantment.REGISTRY.getIDForObject(ench);
+			}
+			else {
+				return -1;
+			}
 		}
 		else {
-			NBTTagList nbttaglist = stack.getEnchantmentTagList();
-
-			for (int i = 0; i < nbttaglist.tagCount(); ++i)	{
-				NBTTagCompound nbttagcompound = nbttaglist.getCompoundTagAt(i);
-				if(Enchantment.getEnchantmentByID(nbttagcompound.getShort("id")).getName().contains(name)){
-					return nbttagcompound.getShort("id");
-				}
-			}
 			return -1;
 		}
 	}


### PR DESCRIPTION
This may seem like a silly PR, but this provides more binary compatibility with vanilla and any mods that modify enchantment properties via ASM or Mixins. I work on a mod called JustEnoughIDs that extends the ID limits of Minecraft and recently (past few days), I released a new update that expanded potion IDs and enchantment IDs to `Integer.MAX_VALUE - 1` and just happened to notice that you use some methods that still use the vanilla format and would cause issues if JEID and SimplyJetpacks 2 were put together with enchantment IDs going above the current ID limit. So I took the liberty of deciphering the two methods you currently use and adapted them to use the Vanilla methods more so and improve compatibility with other mods that could possibly do the same as what JEID does.

If you would like something changed or want to nitpick something about what I have changed here, let me know. Otherwise, my changes work exactly the same as it did before and I will leave pictures below to prove that.

![2018-10-09_16 26 40](https://user-images.githubusercontent.com/10361287/46699858-10888100-cbe9-11e8-830b-c808db0648bf.png)
![2018-10-09_16 26 51](https://user-images.githubusercontent.com/10361287/46699861-12eadb00-cbe9-11e8-91f2-f0c408858645.png)
![2018-10-09_16 27 01](https://user-images.githubusercontent.com/10361287/46699865-14b49e80-cbe9-11e8-89e3-8055440842db.png)
![2018-10-09_16 27 12](https://user-images.githubusercontent.com/10361287/46699870-15e5cb80-cbe9-11e8-8ba1-d35a2b486ec5.png)
![2018-10-09_16 27 22](https://user-images.githubusercontent.com/10361287/46699872-1716f880-cbe9-11e8-8734-f58f4231f9f8.png)

P.S. Sorry for not using Imgur or the such, I figured it would be easier to see the results here rather than going to a different site for the same thing.